### PR TITLE
feat: add production frontend origin

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ app = FastAPI(title="HustleCoin Backend")
 origins = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
-    "https://your-frontend-domain.com", # <-- replace with Mushteba domain when you have it
+    "https://mushteba.com",
 ]
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- add production frontend CORS origin to FastAPI backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3299e2820832a80483d6e3481799e